### PR TITLE
Use absolute imports in GDB scripts.

### DIFF
--- a/gdb/qt5printers/__init__.py
+++ b/gdb/qt5printers/__init__.py
@@ -19,7 +19,7 @@
 # this software.
 
 import gdb.printing
-import core
+from qt5printers import core
 
 """Qt5 Pretty Printers for GDB.
 

--- a/gdb/qt5printers/core.py
+++ b/gdb/qt5printers/core.py
@@ -20,7 +20,7 @@
 
 import gdb.printing
 import itertools
-import typeinfo
+from qt5printers import typeinfo
 try:
     import urlparse
 except ImportError:


### PR DESCRIPTION
Citing pep-0008:
"Implicit relative imports should never be used and have been removed in Python 3."

This fixes problems at least on Arch where gdb is compiled with python3.

Signed-off-by: Roman Kapl <code@rkapl.cz>