### PR TITLE
kde-devel-gdb: fix printing QString

### DIFF
--- a/kde-devel-gdb
+++ b/kde-devel-gdb
@@ -38,13 +38,20 @@ document printq5string
 end
 
 define printqstringdata
-    set $i=0
     set $d = (QStringData *)($arg0)
-    while $i < $d->len
-        printf "%c", (char)($d->unicode[$i++].ucs & 0xff)
+    printf "(QString)0x%x (length=%i): \"", &$arg0, $d->size
+    set $i=0
+    while $i < $d->size
+        set $c=$d->data()[$i++]
+        if $c < 32 || $c > 127
+                printf "\\u0x%04x", $c
+        else
+                printf "%c", (char)$c
+        end
     end
-    printf "\n"
+    printf "\"\n"
 end
+
 document printqstringdata
   Prints the contents of a QStringData
   This is useful when the output of another command (e.g. printqmap)


### PR DESCRIPTION
The old code long time didn't work: "len" field does not exist, data is
a method not a field, "unicode" does not exist, field "ucs" is not
present in data.

Let's just replace it with a new implementation. Credits for that goes
to user apouche from StackOverflow, whose implementation from 2012 year
was only hit by "data" being nowadays a method.

Signed-off-by: Konstantin Kharlamov <Hi-Angel@yandex.ru>